### PR TITLE
Add custom-element base pattern and data-delivery contract.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,14 @@ Follow Prettier defaults (two-space indent, single quotes allowed) for TypeScrip
 - `src/lib/hooks/use-file-bindings.ts` – centralizes AnyWidget binding logic (`read/write`, dedupe, upload/remove).
 - `src/lib/components/file-drop/*` – higher-level panels (`BrowseConfigsPanel`, `SaveConfigPanel`, `SelectedFilesList`, `SelectedFileRow`).
 - `src/lib/components/ui/*` – shadcn-svelte primitives (cards, dialogs, tabs, etc.) in local copies for customization.
-Import from `$lib/...` so Vite aliases resolve correctly. Whenever you scaffold new shadcn components, stage the files (remember `.gitignore` no longer hides `lib/`).
+Whenever you scaffold new shadcn components, stage the files (remember `.gitignore` no longer hides `lib/`).
+
+## Bundled widget imports
+Each bundled workspace under `src/dr_widget/bundled/<name>/` is self-contained. Use the import style that matches where the module lives:
+
+- **`src/lib/` shared code** (hooks, components, utils): import via `$lib/...` when the workspace defines that Vite alias (e.g. `config_file_manager`).
+- **Same-workspace modules** under `src/` (siblings like `./data-channel`, `./components/Hello`): use relative paths. Do not rewrite these as `$lib/...`.
+- **No blanket `$lib/` rule**: only workspaces with a `$lib` → `src/lib` alias in `vite.config.js` / `tsconfig.json` support it. `runtime/` has no `src/lib/` tree and uses relative imports throughout.
 
 ## Testing Guidelines
 Automated tests are not yet configured. When adding features, include manual verification steps in the PR and consider scaffolding Vitest suites under `src/dr_widget/bundled/config_file_manager/src/lib/__tests__`. Snapshotting rendered widgets via `@testing-library/svelte` is preferred once the harness lands; target coverage for new logic should be 80%+. Until then, confirm drag/drop flows in the dev server across Chrome and Firefox before submitting.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,20 @@ static/runtime.js  ── defines ──▶  <dr-*> custom elements (window regi
 ```
 
 - `load_dr_runtime()` reads the built IIFE from disk and wraps it in a define-once guard before handing it to `ActiveHtml`.
-- Each `<dr-*>` element mounts React in its own light DOM; prop updates arrive via `attributeChangedCallback`.
+- Each `<dr-*>` element mounts React in its own light DOM via `defineDrElement()`:
+  - `connectedCallback` → `createRoot` + initial render
+  - `attributeChangedCallback` → re-render (with `observedAttributes` declared)
+  - `disconnectedCallback` → unmount + unsubscribe from the data channel
+- **Design rules baked into the base pattern:** all render logic lives in a shared
+  `#render()` called from both connect and attribute change (never only on connect);
+  use `whenLayoutReady()` from the runtime for geometry — never measure in
+  `connectedCallback`.
+- **Data delivery contract:**
+  - **Small/structured props** → JSON in `data-props`, parsed on each render.
+  - **Large payloads** → `data-ref="<id>"` on the element; payload stored in
+    `window.__drRuntime.data` (`set` / `get` / `subscribe`). Python (or host code)
+    emits the id; the runtime holds the bytes. Channel updates re-render subscribed
+    elements without a marimo attribute change.
 
 ### Config File Manager data flow
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,7 +72,7 @@ Use when the widget needs a component library (Svelte, React, etc.) or transpila
 
 - Manual smoke test in the relevant Vite dev server.
 - Config File Manager: drag/drop, error states, version editing, dirty badge; load legacy and new config shapes; save and verify `{metadata,data}` file shape.
-- Runtime: `<dr-hello>` upgrades; attribute changes re-render in dev and in `notebooks/runtime_hello_widget.py`.
+- Runtime: `<dr-hello>` upgrades; attribute changes re-render in dev and in `notebooks/runtime_hello_widget.py`. Exercise `data-props` JSON and `data-ref` + `window.__drRuntime.data.set(...)` in the same notebook.
 - `npx svelte-check` for Config File Manager type errors.
 - `bun run build` — all bundled workspaces compile without warnings.
 - `uv build` — wheel contains updated `static/` assets.

--- a/notebooks/runtime_hello_widget.py
+++ b/notebooks/runtime_hello_widget.py
@@ -1,7 +1,9 @@
 # Playwright verification (manual): run `marimo run notebooks/runtime_hello_widget.py
 # --headless --no-token -p 2718`, drive with Playwright (channel="chrome"), assert
 # dr-hello upgrades, slider changes update the name attribute in place (no
-# disconnect/reconnect), and React re-renders the greeting text.
+# disconnect/reconnect), and React re-renders the greeting text. Also assert
+# dr-props-panel renders data-props items and updates when __drRuntime.data.set
+# is called for the data-ref id.
 
 import marimo
 
@@ -11,7 +13,7 @@ app = marimo.App(width="medium")
 with app.setup:
     import marimo as mo
 
-    from dr_widget.inline import load_dr_runtime
+    from dr_widget.inline import ActiveHtml, load_dr_runtime
 
     NAMES = ["Ada", "Grace", "Alan", "Katherine", "Tim", "World"]
 
@@ -37,11 +39,31 @@ def _():
 
 @app.cell(hide_code=True)
 def _(name_index):
+    import json
+
     name = NAMES[name_index.value]
+    DATA_REF = "demo-props-panel"
+    small_props = json.dumps({"title": "Small data-props demo", "items": [name]})
+    channel_seed = json.dumps(
+        {
+            "title": "Large data-ref demo",
+            "items": ["alpha", "beta", "gamma", "delta"],
+        }
+    )
+
     mo.vstack(
         [
             mo.md(f"Selected name: **{name}**"),
             mo.Html(f'<dr-hello name="{name}"></dr-hello>'),
+            mo.Html(f"<dr-props-panel data-props='{small_props}'></dr-props-panel>"),
+            mo.Html(f'<dr-props-panel data-ref="{DATA_REF}"></dr-props-panel>'),
+            ActiveHtml(
+                html=(
+                    "<script>"
+                    f"window.__drRuntime?.data.set({json.dumps(DATA_REF)}, {channel_seed});"
+                    "</script>"
+                )
+            ),
         ]
     )
     return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dr-widget"
-version = "0.2.1"
+version = "0.2.2"
 description = "Widgets to use with marimo notebooks"
 readme = "README.md"
 authors = [

--- a/src/dr_widget/bundled/runtime/src/components/PropsPanel.tsx
+++ b/src/dr_widget/bundled/runtime/src/components/PropsPanel.tsx
@@ -5,8 +5,13 @@ type PropsPanelProps = {
 };
 
 export function PropsPanel({ title, items }: PropsPanelProps) {
-  const heading = title?.trim() || 'Props panel';
-  const rows = items ?? [];
+  const heading =
+    typeof title === 'string' && title.trim().length > 0
+      ? title.trim()
+      : 'Props panel';
+  const rows = Array.isArray(items)
+    ? items.filter((item): item is string => typeof item === 'string')
+    : [];
 
   return (
     <div>

--- a/src/dr_widget/bundled/runtime/src/components/PropsPanel.tsx
+++ b/src/dr_widget/bundled/runtime/src/components/PropsPanel.tsx
@@ -1,0 +1,25 @@
+type PropsPanelProps = {
+  title?: string;
+  items?: string[];
+  __dataRef?: string;
+};
+
+export function PropsPanel({ title, items }: PropsPanelProps) {
+  const heading = title?.trim() || 'Props panel';
+  const rows = items ?? [];
+
+  return (
+    <div>
+      <strong>{heading}</strong>
+      {rows.length > 0 ? (
+        <ul>
+          {rows.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>No items.</p>
+      )}
+    </div>
+  );
+}

--- a/src/dr_widget/bundled/runtime/src/data-channel.ts
+++ b/src/dr_widget/bundled/runtime/src/data-channel.ts
@@ -1,0 +1,51 @@
+export type DataChannelListener = (payload: unknown) => void;
+
+export type DataChannel = {
+  set: (id: string, payload: unknown) => void;
+  get: (id: string) => unknown;
+  delete: (id: string) => void;
+  subscribe: (id: string, listener: DataChannelListener) => () => void;
+};
+
+export function createDataChannel(): DataChannel {
+  const payloads = new Map<string, unknown>();
+  const listeners = new Map<string, Set<DataChannelListener>>();
+
+  function notify(id: string, payload: unknown): void {
+    const subs = listeners.get(id);
+    if (!subs) {
+      return;
+    }
+    for (const listener of subs) {
+      listener(payload);
+    }
+  }
+
+  return {
+    set(id, payload) {
+      payloads.set(id, payload);
+      notify(id, payload);
+    },
+    get(id) {
+      return payloads.get(id);
+    },
+    delete(id) {
+      payloads.delete(id);
+      listeners.delete(id);
+    },
+    subscribe(id, listener) {
+      let subs = listeners.get(id);
+      if (!subs) {
+        subs = new Set();
+        listeners.set(id, subs);
+      }
+      subs.add(listener);
+      return () => {
+        subs?.delete(listener);
+        if (subs && subs.size === 0) {
+          listeners.delete(id);
+        }
+      };
+    },
+  };
+}

--- a/src/dr_widget/bundled/runtime/src/data-channel.ts
+++ b/src/dr_widget/bundled/runtime/src/data-channel.ts
@@ -31,7 +31,7 @@ export function createDataChannel(): DataChannel {
     },
     delete(id) {
       payloads.delete(id);
-      listeners.delete(id);
+      notify(id, undefined);
     },
     subscribe(id, listener) {
       let subs = listeners.get(id);
@@ -40,9 +40,10 @@ export function createDataChannel(): DataChannel {
         listeners.set(id, subs);
       }
       subs.add(listener);
+      const currentSubs = subs;
       return () => {
-        subs?.delete(listener);
-        if (subs && subs.size === 0) {
+        currentSubs.delete(listener);
+        if (currentSubs.size === 0 && listeners.get(id) === currentSubs) {
           listeners.delete(id);
         }
       };

--- a/src/dr_widget/bundled/runtime/src/define-element.tsx
+++ b/src/dr_widget/bundled/runtime/src/define-element.tsx
@@ -4,56 +4,119 @@ import {
   type Root,
 } from 'react-dom/client';
 
-function propsFromAttributes(
-  el: HTMLElement,
-  observedAttributes: string[],
-): Record<string, string | undefined> {
-  const props: Record<string, string | undefined> = {};
-  for (const name of observedAttributes) {
-    props[name] = el.getAttribute(name) ?? undefined;
-  }
-  return props;
+import type { DataChannel } from './data-channel';
+import {
+  DEFAULT_DATA_REF_ATTRIBUTE,
+  DEFAULT_PROPS_ATTRIBUTE,
+  parseElementProps,
+  readDataRef,
+  type ParsePropsOptions,
+} from './parse-props';
+
+export type DrElementOptions<P extends Record<string, unknown>> =
+  ParsePropsOptions & {
+    parseProps?: (
+      element: HTMLElement,
+      dataChannel: DataChannel,
+    ) => P;
+  };
+
+function isOptions<P extends Record<string, unknown>>(
+  value: readonly string[] | DrElementOptions<P>,
+): value is DrElementOptions<P> {
+  return !Array.isArray(value);
 }
 
-export function defineDrElement(
+function resolveOptions<P extends Record<string, unknown>>(
+  observedAttributesOrOptions: readonly string[] | DrElementOptions<P>,
+): DrElementOptions<P> {
+  if (isOptions(observedAttributesOrOptions)) {
+    return observedAttributesOrOptions;
+  }
+  return { observedAttributes: observedAttributesOrOptions };
+}
+
+export function defineDrElement<P extends Record<string, unknown>>(
   tag: string,
-  Component: ComponentType<Record<string, string | undefined>>,
-  observedAttributes: string[],
+  Component: ComponentType<P>,
+  observedAttributesOrOptions: readonly string[] | DrElementOptions<P>,
+  dataChannel: DataChannel,
 ): void {
   if (customElements.get(tag)) {
     return;
   }
 
+  const options = resolveOptions(observedAttributesOrOptions);
+  const propsAttribute = options.propsAttribute ?? DEFAULT_PROPS_ATTRIBUTE;
+  const dataRefAttribute = options.dataRefAttribute ?? DEFAULT_DATA_REF_ATTRIBUTE;
+
+  const readProps = (element: HTMLElement): P => {
+    if (options.parseProps) {
+      return options.parseProps(element, dataChannel);
+    }
+    return parseElementProps(element, dataChannel, options) as P;
+  };
+
   class DrElement extends HTMLElement {
     static get observedAttributes() {
-      return observedAttributes;
+      const attrs = new Set<string>(options.observedAttributes ?? []);
+      attrs.add(propsAttribute);
+      attrs.add(dataRefAttribute);
+      return [...attrs];
     }
 
     #root: Root | null = null;
+    #unsubscribeData: (() => void) | null = null;
 
     connectedCallback() {
       this.#root = createRoot(this);
+      this.#bindDataChannel();
       this.#render();
     }
 
-    attributeChangedCallback() {
+    attributeChangedCallback(
+      _name: string,
+      oldValue: string | null,
+      newValue: string | null,
+    ) {
+      if (oldValue === newValue) {
+        return;
+      }
+      this.#bindDataChannel();
       this.#render();
     }
 
     disconnectedCallback() {
+      this.#unsubscribeData?.();
+      this.#unsubscribeData = null;
       this.#root?.unmount();
       this.#root = null;
+    }
+
+    #bindDataChannel() {
+      this.#unsubscribeData?.();
+      this.#unsubscribeData = null;
+
+      const dataRef = readDataRef(this, dataRefAttribute);
+      if (!dataRef) {
+        return;
+      }
+
+      this.#unsubscribeData = dataChannel.subscribe(dataRef, () => {
+        this.#render();
+      });
     }
 
     #render() {
       if (!this.#root) {
         return;
       }
-      this.#root.render(
-        <Component {...propsFromAttributes(this, observedAttributes)} />,
-      );
+      this.#root.render(<Component {...readProps(this)} />);
     }
   }
 
   customElements.define(tag, DrElement);
 }
+
+export { whenLayoutReady } from './layout';
+export type { LayoutReadyCallback } from './layout';

--- a/src/dr_widget/bundled/runtime/src/define-element.tsx
+++ b/src/dr_widget/bundled/runtime/src/define-element.tsx
@@ -75,14 +75,19 @@ export function defineDrElement<P extends Record<string, unknown>>(
     }
 
     attributeChangedCallback(
-      _name: string,
+      name: string,
       oldValue: string | null,
       newValue: string | null,
     ) {
       if (oldValue === newValue) {
         return;
       }
-      this.#bindDataChannel();
+      if (!this.isConnected) {
+        return;
+      }
+      if (name === dataRefAttribute) {
+        this.#bindDataChannel();
+      }
       this.#render();
     }
 

--- a/src/dr_widget/bundled/runtime/src/globals.d.ts
+++ b/src/dr_widget/bundled/runtime/src/globals.d.ts
@@ -1,11 +1,15 @@
 import type { ComponentType } from 'react';
 
+import type { DataChannel } from './data-channel';
+import type { DrElementOptions } from './define-element';
+
 export type DrRuntime = {
-  defineDrElement: (
+  defineDrElement: <P extends Record<string, unknown>>(
     tag: string,
-    Component: ComponentType<Record<string, string | undefined>>,
-    observedAttributes: string[],
+    Component: ComponentType<P>,
+    observedAttributesOrOptions: readonly string[] | DrElementOptions<P>,
   ) => void;
+  data: DataChannel;
   version: string;
 };
 

--- a/src/dr_widget/bundled/runtime/src/index.tsx
+++ b/src/dr_widget/bundled/runtime/src/index.tsx
@@ -1,11 +1,17 @@
 import { Hello } from './components/Hello';
+import { PropsPanel } from './components/PropsPanel';
+import { createDataChannel } from './data-channel';
 import { defineDrElement } from './define-element';
 
-const RUNTIME_VERSION = '0.1.0';
+const RUNTIME_VERSION = '0.2.0';
+const dataChannel = createDataChannel();
 
-defineDrElement('dr-hello', Hello, ['name']);
+defineDrElement('dr-hello', Hello, ['name'], dataChannel);
+defineDrElement('dr-props-panel', PropsPanel, [], dataChannel);
 
 window.__drRuntime = {
-  defineDrElement,
+  defineDrElement: (tag, Component, observedAttributesOrOptions) =>
+    defineDrElement(tag, Component, observedAttributesOrOptions, dataChannel),
+  data: dataChannel,
   version: RUNTIME_VERSION,
 };

--- a/src/dr_widget/bundled/runtime/src/layout.ts
+++ b/src/dr_widget/bundled/runtime/src/layout.ts
@@ -11,13 +11,15 @@ export function whenLayoutReady(
   callback: LayoutReadyCallback,
 ): () => void {
   let cancelled = false;
+  let completed = false;
   let observer: ResizeObserver | null = null;
 
   const run = () => {
-    if (cancelled) {
+    if (cancelled || completed) {
       return;
     }
     if (element.clientWidth > 0 || element.clientHeight > 0) {
+      completed = true;
       callback(element);
       observer?.disconnect();
       observer = null;

--- a/src/dr_widget/bundled/runtime/src/layout.ts
+++ b/src/dr_widget/bundled/runtime/src/layout.ts
@@ -1,0 +1,39 @@
+export type LayoutReadyCallback = (element: HTMLElement) => void;
+
+/**
+ * Run `callback` once the element has non-zero layout dimensions.
+ *
+ * Design rule 2: never read geometry in `connectedCallback` — layout may not
+ * be ready yet. Prefer this helper (rAF + ResizeObserver) for sizing work.
+ */
+export function whenLayoutReady(
+  element: HTMLElement,
+  callback: LayoutReadyCallback,
+): () => void {
+  let cancelled = false;
+  let observer: ResizeObserver | null = null;
+
+  const run = () => {
+    if (cancelled) {
+      return;
+    }
+    if (element.clientWidth > 0 || element.clientHeight > 0) {
+      callback(element);
+      observer?.disconnect();
+      observer = null;
+      return;
+    }
+    requestAnimationFrame(run);
+  };
+
+  observer = new ResizeObserver(() => {
+    run();
+  });
+  observer.observe(element);
+  requestAnimationFrame(run);
+
+  return () => {
+    cancelled = true;
+    observer?.disconnect();
+  };
+}

--- a/src/dr_widget/bundled/runtime/src/parse-props.ts
+++ b/src/dr_widget/bundled/runtime/src/parse-props.ts
@@ -1,0 +1,85 @@
+import type { DataChannel } from './data-channel';
+
+export const DEFAULT_PROPS_ATTRIBUTE = 'data-props';
+export const DEFAULT_DATA_REF_ATTRIBUTE = 'data-ref';
+
+export type ParsePropsOptions = {
+  observedAttributes?: readonly string[];
+  propsAttribute?: string;
+  dataRefAttribute?: string;
+};
+
+export type ParsedProps = Record<string, unknown>;
+
+function parseJsonAttribute(
+  element: HTMLElement,
+  attributeName: string,
+): ParsedProps | undefined {
+  const raw = element.getAttribute(attributeName);
+  if (raw === null) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as ParsedProps;
+    }
+  } catch {
+    console.warn(
+      `[dr-runtime] Invalid JSON in ${attributeName} on <${element.tagName.toLowerCase()}>`,
+    );
+  }
+  return undefined;
+}
+
+function mergeChannelPayload(
+  props: ParsedProps,
+  payload: unknown,
+): ParsedProps {
+  if (payload === undefined) {
+    return props;
+  }
+  if (
+    typeof payload === 'object' &&
+    payload !== null &&
+    !Array.isArray(payload)
+  ) {
+    return { ...props, ...(payload as ParsedProps) };
+  }
+  return { ...props, data: payload };
+}
+
+export function parseElementProps(
+  element: HTMLElement,
+  dataChannel: DataChannel,
+  options: ParsePropsOptions = {},
+): ParsedProps {
+  const props: ParsedProps = {};
+  const observedAttributes = options.observedAttributes ?? [];
+
+  for (const name of observedAttributes) {
+    props[name] = element.getAttribute(name) ?? undefined;
+  }
+
+  const propsAttribute = options.propsAttribute ?? DEFAULT_PROPS_ATTRIBUTE;
+  const jsonProps = parseJsonAttribute(element, propsAttribute);
+  if (jsonProps) {
+    Object.assign(props, jsonProps);
+  }
+
+  const dataRefAttribute = options.dataRefAttribute ?? DEFAULT_DATA_REF_ATTRIBUTE;
+  const dataRef = element.getAttribute(dataRefAttribute);
+  if (dataRef) {
+    props.__dataRef = dataRef;
+    return mergeChannelPayload(props, dataChannel.get(dataRef));
+  }
+
+  return props;
+}
+
+export function readDataRef(
+  element: HTMLElement,
+  dataRefAttribute: string = DEFAULT_DATA_REF_ATTRIBUTE,
+): string | undefined {
+  return element.getAttribute(dataRefAttribute) ?? undefined;
+}

--- a/uv.lock
+++ b/uv.lock
@@ -221,7 +221,7 @@ wheels = [
 
 [[package]]
 name = "dr-widget"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary

Implements the Phase 0 foundation for marimo_utils#9: a reusable light-DOM custom-element base pattern and a data-delivery contract in the dr_widget runtime.

- **`defineDrElement`** — `connectedCallback` creates a React root; `attributeChangedCallback` re-renders via shared `#render()`; `disconnectedCallback` unmounts and unsubscribes from the data channel. Declares `observedAttributes` including `data-props` and `data-ref`.
- **`whenLayoutReady`** — helper to defer geometry reads (design rule 2).
- **Data contract** — small structured props via `data-props` JSON; large payloads via `data-ref` + `window.__drRuntime.data` (`set` / `get` / `subscribe`).
- **Demo** — `<dr-props-panel>` proof element; `runtime_hello_widget.py` exercises both delivery paths.

Fixes drothermel/marimo_utils#9

## Test plan

- [x] `bun run build:runtime`
- [x] `uv build` (0.2.2)
- [x] `uv run marimo check notebooks/runtime_hello_widget.py`
- [ ] Manual: `marimo run notebooks/runtime_hello_widget.py` — slider re-renders `<dr-hello>`; panels show `data-props` and `data-ref` payloads