### PR TITLE
Add dr-badge custom element for foundation proof (#12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dr-widget"
-version = "0.2.2"
+version = "0.2.3"
 description = "Widgets to use with marimo notebooks"
 readme = "README.md"
 authors = [

--- a/src/dr_widget/bundled/runtime/src/components/Badge.tsx
+++ b/src/dr_widget/bundled/runtime/src/components/Badge.tsx
@@ -1,0 +1,9 @@
+type BadgeProps = {
+  label?: string;
+  className?: string;
+};
+
+export function Badge({ label, className }: BadgeProps) {
+  const text = label?.trim() ?? '';
+  return <span className={className}>{text}</span>;
+}

--- a/src/dr_widget/bundled/runtime/src/index.tsx
+++ b/src/dr_widget/bundled/runtime/src/index.tsx
@@ -1,3 +1,4 @@
+import { Badge } from './components/Badge';
 import { Hello } from './components/Hello';
 import { PropsPanel } from './components/PropsPanel';
 import { createDataChannel } from './data-channel';
@@ -7,6 +8,7 @@ const RUNTIME_VERSION = '0.2.0';
 const dataChannel = createDataChannel();
 
 defineDrElement('dr-hello', Hello, ['name'], dataChannel);
+defineDrElement('dr-badge', Badge, [], dataChannel);
 defineDrElement('dr-props-panel', PropsPanel, [], dataChannel);
 
 window.__drRuntime = {


### PR DESCRIPTION
## Summary
- Add `dr-badge` React custom element to the shared runtime
- Register via `defineDrElement('dr-badge', Badge, [], dataChannel)`
- Bump version to 0.2.3 for marimo_utils pin

## Test plan
- [ ] `bun run build:runtime` succeeds
- [ ] marimo_utils foundation proof probe renders badge variants

Related: drothermel/marimo_utils#12